### PR TITLE
[FIX] Fix "Add to cart " button to support product data without stock value

### DIFF
--- a/app/views/pages/templates/product.liquid
+++ b/app/views/pages/templates/product.liquid
@@ -170,7 +170,7 @@ handle: product
           </div>
         </div>
         <div class="row">
-        {% assign stock_state = variant.stocks %}
+        {% assign stock_state = variant.stock.global.state %}
         {% if stock_state != null and  stock_state != ''%}
           <div class="col-12 text-left product-stock-state">
             <span class="{{variant.stock.global.state}}">

--- a/app/views/pages/templates/product.liquid
+++ b/app/views/pages/templates/product.liquid
@@ -170,14 +170,15 @@ handle: product
           </div>
         </div>
         <div class="row">
-        {% if variant.stock.global.state != null and  variant.stock.global.state != ''%}
+        {% assign stock_state = variant.stocks %}
+        {% if stock_state != null and  stock_state != ''%}
           <div class="col-12 text-left product-stock-state">
             <span class="{{variant.stock.global.state}}">
               {{variant.stock.global.state | prepend: 'product_stock_state_' | translate}}
             </span>
           </div>
         {% endif %}
-        {% if variant.stock.global.state =='in_stock' or variant.stock.global.state == 'in_limited_stock' %}
+        {% if stock_state == null or stock_state =='in_stock' or stock_state == 'in_limited_stock' %}
           <div class="col-12  text-right d-none d-sm-block">
             <button type="submit" class="btn btn-success btn-lg btn-block">
               {{"product_add_to_cart" | translate }}


### PR DESCRIPTION
Display Add to cart button even if the product data has not stock state value. This button depending on the status of the stock if it's defined on the product data.