### PR TITLE
[FIX] Switch to delivery_carrier API method

### DIFF
--- a/app/views/sections/cart_delivery.liquid
+++ b/app/views/sections/cart_delivery.liquid
@@ -16,7 +16,8 @@ settings:
   type: text
 blocks: []
 ---
-{% erp get 'cart/get_delivery_methods' as delivery_methods %}
+{% erp get 'delivery_carriers' as delivery_carriers with target: 'current_cart' %}
+{% assign delivery_methods = delivery_carriers.data %}
 {% assign selected_carrier = store.cart.shipping.selected_carrier %}
 {% assign is_selected_carrier = false %}
 {% if delivery_methods.size > 0 %}


### PR DESCRIPTION
Switch to delivery_carrier API method instead of an old deprecated cart's method to get carrier list on cart page.